### PR TITLE
Fixing a bug in the cleanup scripts

### DIFF
--- a/gke-to-gke-peering/cleanup.sh
+++ b/gke-to-gke-peering/cleanup.sh
@@ -1,5 +1,4 @@
-#!/bin/bash -e
-
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/gke-to-gke-vpn/cleanup.sh
+++ b/gke-to-gke-vpn/cleanup.sh
@@ -1,5 +1,4 @@
-#!/bin/bash -e
-
+#!/usr/bin/env bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The cleanup scripts had a "-e" flag which caused deletion to fail
if the clusters had not deployed fully.  Removing it.