### PR TITLE
reduced the number of docker images used and reduced the size

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,6 +66,9 @@ spec:
           sh "gcloud config set compute/zone ${env.CLUSTER_ZONE}"
           sh "gcloud config set core/project ${env.PROJECT_ID}"
           sh "gcloud config set compute/region ${env.REGION}"
+
+          // Build and push container image to pso_examples
+          sh "make build_container"
          }
     }
     stage('Lint') {

--- a/Makefile
+++ b/Makefile
@@ -57,3 +57,8 @@ check_trailing_whitespace:
 check_headers:
 	@echo "Checking file headers"
 	@python test/verify_boilerplate.py
+
+.PHONY: build_container
+build_container:
+	gcloud builds submit container --project=pso-examples \
+	  --config="container/cloudbuild.yaml"

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The kubectl CLI is used to interteract with both Kubernetes Engine and kubernete
 for multiple platforms are available online.
 
 ## Directory Structure
-1. The [gke-to-gke-vpc-peering](gke-to-gke-vpc-peering) and [gke-to-gke-vpn](gke-to-gke-vpn) folders each contain a project.
-1. README files exist for the above examples; [gke-to-gke-vpc-peering/README.md](gke-to-gke-vpc-peering/README.md) and [gke-to-gke-vpn/README.md](gke-to-gke-vpn/README.md).
+1. The [gke-to-gke-peering](gke-to-gke-peering) and [gke-to-gke-vpn](gke-to-gke-vpn) folders each contain a project.
+1. README files exist for the above examples; [gke-to-gke-peering/README.md](gke-to-gke-peering/README.md) and [gke-to-gke-vpn/README.md](gke-to-gke-vpn/README.md).
 1. The [network](network) folder contains the manifest files and deployment manager templates to setup networks.
 1. The [clusters](clusters) folder contains the manifest files and deployment manager templates to create Kubernetes Engine clusters.
 1. The [manifests](clusters) folder contains the manifest files to create Kubernetes Engine services.

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -12,24 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-### nginx app deployment configuration
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-nginx
-spec:
-  selector:
-    matchLabels:
-      run: my-nginx
-  replicas: 2
-  template:
-    metadata:
-      labels:
-        run: my-nginx
-    spec:
-      containers:
-      - name: my-nginx
-        image: gcr.io/pso-examples/nginx-curl:1.0.0
-        ports:
-        - containerPort: 80
+FROM nginx:alpine
 
+RUN apk add --no-cache curl

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,10 @@
+# Nginx Container
+
+This project provides an Alpine Nginx container with curl to test pod to service
+ communications.
+
+The container is available via:
+
+```console
+docker pull gcr.io/pso-examples/nginx-curl:1.0.0
+```

--- a/container/cloudbuild.yaml
+++ b/container/cloudbuild.yaml
@@ -1,0 +1,19 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+steps:
+- name: 'gcr.io/cloud-builders/docker'
+  args: [ 'build', '-t', 'gcr.io/pso-examples/nginx-curl:1.0.0', '.']
+images:
+- 'gcr.io/pso-examples/nginx-curl:1.0.0'

--- a/gke-to-gke-peering/README.md
+++ b/gke-to-gke-peering/README.md
@@ -151,7 +151,7 @@ When not using Cloud Shell, the following tools are required.
 1. Increase quotas from below resources. Refer to https://cloud.google.com/compute/quotas.
 	* Forwarding rules (minimun 24)
 	* In-use IP addresses global (minimun 20)
-	* Backend services (minimun 10)
+	* Backend services (minimun 8)
 	* Firewall rules (minimun 42)
 
 1. Pull the code from git repo.

--- a/gke-to-gke-peering/install.sh
+++ b/gke-to-gke-peering/install.sh
@@ -52,7 +52,7 @@ if ! meets_quota "${PROJECT_ID}" "IN_USE_ADDRESSES" 20; then
 fi
 
 ### Ensure that the Backend services quota is met
-if ! meets_quota "${PROJECT_ID}" "BACKEND_SERVICES" 10; then
+if ! meets_quota "${PROJECT_ID}" "BACKEND_SERVICES" 8; then
   echo "Refer to https://cloud.google.com/compute/quotas"
   echo "Terminating..."
   exit 1

--- a/gke-to-gke-vpn/README.md
+++ b/gke-to-gke-vpn/README.md
@@ -175,7 +175,7 @@ When not using Cloud Shell, the following tools are required.
 1. Increase quotas from below resources. Refer to https://cloud.google.com/compute/quotas.
     * Forwarding rules (minimum 24)
     * In-use IP addresses global (minimum 20)
-    * Backend services (minimum 10)
+    * Backend services (minimum 8)
     * Firewall rules (minimum 42)
 1. Pull the code from git repo.
 1. Optionally, customize the configuration in .yaml files under /network/ or /clusters/ or /manifests/, if needed.

--- a/gke-to-gke-vpn/install.sh
+++ b/gke-to-gke-vpn/install.sh
@@ -51,7 +51,7 @@ if ! meets_quota "${PROJECT_ID}" "IN_USE_ADDRESSES" 20; then
 fi
 
 ### Ensure that the Backend services quota is met
-if ! meets_quota "${PROJECT_ID}" "BACKEND_SERVICES" 10; then
+if ! meets_quota "${PROJECT_ID}" "BACKEND_SERVICES" 8; then
   echo "Refer to https://cloud.google.com/compute/quotas"
   echo "Terminating..."
   exit 1

--- a/validate-pod-to-service-communication.sh
+++ b/validate-pod-to-service-communication.sh
@@ -50,16 +50,16 @@ echo "----------------------------------------"
 echo "Testing: cluster1 -> cluster1 clusterIP service"
 SERVICE_IP=$(kubectl get services --field-selector metadata.name=my-nginx \
   -o jsonpath='{.items[].spec.clusterIP}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}"
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}"
 echo "----------------------------------------"
 
 echo "----------------------------------------"
 echo "Testing: cluster1 -> cluster1 nodeport service"
 SERVICE_IP=$(kubectl get services --field-selector metadata.name=my-nginx-nodeport \
   -o jsonpath='{.items[].spec.clusterIP}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}:8080"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}":8080
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}:8080"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}":8080
 echo "----------------------------------------"
 
 ### Internal Load Balancer tests
@@ -67,8 +67,8 @@ echo "----------------------------------------"
 echo "Testing: cluster1 -> cluster1 ILB service"
 SERVICE_IP=$(kubectl get services --field-selector metadata.name=my-nginx-ilb \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}:8080"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}":8080
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}:8080"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}":8080
 echo "----------------------------------------"
 
 echo "----------------------------------------"
@@ -76,8 +76,8 @@ echo "Testing: cluster1 -> cluster3 ILB (same region)"
 SERVICE_IP=$( kubectl get services --cluster "${CLUSTER3_CONTEXT}" \
   --field-selector metadata.name=my-nginx-ilb \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}:8080"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}":8080
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}:8080"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}":8080
 echo "----------------------------------------"
 
 echo "----------------------------------------"
@@ -86,9 +86,9 @@ SERVICE_IP=$( kubectl get services --cluster "${CLUSTER2_CONTEXT}" \
   --field-selector metadata.name=my-nginx-ilb \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
 echo "kubectl exec --cluster ${CLUSTER4_CONTEXT} \
-  ${POD_NAME_CLUSTER4} -c my-test -- curl -s -I ${SERVICE_IP}:8080"
+  ${POD_NAME_CLUSTER4} -c my-nginx -- curl -s -I ${SERVICE_IP}:8080"
 kubectl exec --cluster "${CLUSTER4_CONTEXT}" \
-  "${POD_NAME_CLUSTER4}" -c my-test -- curl -s -I "${SERVICE_IP}":8080
+  "${POD_NAME_CLUSTER4}" -c my-nginx -- curl -s -I "${SERVICE_IP}":8080
 echo "----------------------------------------"
 
 #### Ingress tests
@@ -96,8 +96,8 @@ echo "----------------------------------------"
 echo "Testing: cluster1 -> cluster1 ingress service"
 SERVICE_IP=$(kubectl get ingress --field-selector metadata.name=my-nginx-ingress \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}"
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}"
 echo "----------------------------------------"
 
 echo "----------------------------------------"
@@ -105,8 +105,8 @@ echo "Testing: cluster1 -> cluster2 ingress service"
 SERVICE_IP=$(kubectl get ingress --cluster "${CLUSTER2_CONTEXT}" \
   --field-selector metadata.name=my-nginx-ingress \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}"
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}"
 echo "----------------------------------------"
 
 echo "----------------------------------------"
@@ -114,8 +114,8 @@ echo "Testing: cluster1 -> cluster3 ingress service"
 SERVICE_IP=$(kubectl get ingress --cluster "${CLUSTER3_CONTEXT}" \
   --field-selector metadata.name=my-nginx-ingress \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}"
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}"
 echo "----------------------------------------"
 
 echo "----------------------------------------"
@@ -123,8 +123,8 @@ echo "Testing: cluster1 -> cluster4 ingress service"
 SERVICE_IP=$(kubectl get ingress --cluster "${CLUSTER4_CONTEXT}" \
   --field-selector metadata.name=my-nginx-ingress \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}"
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}"
 echo "----------------------------------------"
 
 #### Load Balancer tests
@@ -132,8 +132,8 @@ echo "----------------------------------------"
 echo "Testing: cluster1 -> cluster1 LB service"
 SERVICE_IP=$(kubectl get services --field-selector metadata.name=my-nginx-lb \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}:8080"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}":8080
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}:8080"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}":8080
 echo "----------------------------------------"
 
 echo "----------------------------------------"
@@ -141,8 +141,8 @@ echo "Testing: cluster1 -> cluster2 LB service (cross region)"
 SERVICE_IP=$( kubectl get services --cluster "${CLUSTER2_CONTEXT}" \
   --field-selector metadata.name=my-nginx-lb \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}:8080"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}":8080
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}:8080"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}":8080
 echo "----------------------------------------"
 
 echo "----------------------------------------"
@@ -150,8 +150,8 @@ echo "Testing: cluster1 -> cluster3 LB service"
 SERVICE_IP=$( kubectl get services --cluster "${CLUSTER3_CONTEXT}" \
   --field-selector metadata.name=my-nginx-lb \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}:8080"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}":8080
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}:8080"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}":8080
 echo "----------------------------------------"
 
 echo "----------------------------------------"
@@ -159,6 +159,6 @@ echo "Testing: cluster1 -> cluster4 LB service (cross region)"
 SERVICE_IP=$( kubectl get services --cluster "${CLUSTER4_CONTEXT}" \
   --field-selector metadata.name=my-nginx-lb \
   -o jsonpath='{.items[].status.loadBalancer.ingress[].ip}')
-echo "kubectl exec ${POD_NAME} -c my-test -- curl -s -I ${SERVICE_IP}:8080"
-kubectl exec "${POD_NAME}" -c my-test -- curl -s -I "${SERVICE_IP}":8080
+echo "kubectl exec ${POD_NAME} -c my-nginx -- curl -s -I ${SERVICE_IP}:8080"
+kubectl exec "${POD_NAME}" -c my-nginx -- curl -s -I "${SERVICE_IP}":8080
 echo "----------------------------------------"


### PR DESCRIPTION
Forgot to add this to the last PR
- Updated the readme and checks to the new service backend requirement
- The demo was using two container images nginx(109MB) and gcr.io/k8s-testimages/kettle:latest(870MB). I replaced both images with a new container gcr.io/pso-examples/nginx-curl(19.3MB)
- The my-nginx deployment is now running one container in the pod instead of two